### PR TITLE
fix: launch demo button redirect to new sopbox demo site

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
                                     </ul>
                                 </div> <!-- navbar collapse -->
                                 <div class="button add-list-button">
-                                    <a href="https://sop-demo.parsimony.com/" target="_blank" class="btn">
+                                    <a href="https://sopbox-demo.parsimony.com/" target="_blank" class="btn">
                                         Launch Demo
                                     </a>
                                 </div>
@@ -108,12 +108,6 @@
                             <h1 class="wow fadeInLeft" data-wow-delay=".4s">Meet SOPbox: SOPs That Simply Work</h1>
                             <p class="wow fadeInLeft" data-wow-delay=".6s">SOPbox gives you the Standard Operating
                                 Procedures you need, wherever you need them.</p>
-                            <div class="button wow fadeInLeft" data-wow-delay=".8s">
-                                <a href="https://chrome.google.com/webstore/detail/parsimony-sopbox/kkgjmmjflaefighkbmlfbhjcbphmipde?hl=en"
-                                    class="btn"><i class="lni lni-chrome"></i> Chrome Extension</a>
-                                <a href="https://addons.mozilla.org/en-US/firefox/addon/parsimony-sopbox/"
-                                    class="btn btn-alt"><i class="lni lni-firefox"></i> Firefox Extension</a>
-                            </div>
                         </div>
                     </div>
                     <div class="col-lg-7 col-md-12 col-12">


### PR DESCRIPTION
launch demo button redirect to new sopbox demo site - https://sopbox-demo.parsimony.com/

ClickUp - https://app.clickup.com/t/32q1kvd